### PR TITLE
Create version 1.0.1 for public release

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
+dist/
 node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,3 @@
 .prettierrc.js
 jest.config.ts
 test/
-tsconfig.build.json
-tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "structured-elements",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "structured-elements",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "LGPLv3",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "format-check": "prettier -c .",
     "lint": "npm run eslint && npm run format",
     "lint-check": "npm run eslint-check && npm run format-check",
-    "test": "jest"
+    "test": "jest",
+    "verify": "npm run lint-check && npm run test && npm run build"
   },
   "types": "dist/index.d.ts",
   "version": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
     "verify": "npm run lint-check && npm run test && npm run build"
   },
   "types": "dist/index.d.ts",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "baseUrl": ".",
+    "rootDir": "./src",
+    "baseUrl": "./src",
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
@@ -9,13 +10,12 @@
     "noErrorTruncation": true,
     "outDir": "./dist",
     "paths": {
-      "@": ["src/index"],
-      "@/*": ["src/*"]
+      "@": ["./index"],
+      "@/*": ["./*"]
     },
     "sourceMap": true,
     "strict": true,
     "target": "ES2019"
   },
-  "exclude": ["node_modules", "test"],
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,5 @@
     "strict": true,
     "target": "ES2019"
   },
-  "exclude": ["node_modules"],
-  "include": ["src", "test"]
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
Context:

The initial 1.0.0 release revealed some problems in the build process:

- The `dist` directory included two copies of the source code; one
  directly inside `dist/` and the other in `dist/src`.
- The `dist` directory mistakenly included the `test` directory.
- When installed as a package, the code in `node_modules` could not be
  navigated using TypeScript-enabled editor features because there was
  no `tsconfig.json` in the root directory.

Changes:

The installed package is now structured as follows:

- `dist/`: Contains a compiled JavaScript version of the package's `src`
  directory, along with type definitions and mappings.
- `src/`: Contains the original TypeScript source code.
- `LICENSE.md`
- `package.json`
- `README.md`
- `tsconfig.build.json`: Included to help document the built package.
- `tsconfig.json`: Included so that editors can navigate the TypeScript
  source code, since most imports use path aliases.

This new structure solves the issues outlined in the Context section.
